### PR TITLE
Remove the generic feeder field from JsonParser

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,17 +22,17 @@
 //! let json = r#"{"name": "Elvis"}"#.as_bytes();
 //!
 //! let mut feeder = PushJsonFeeder::new();
-//! let mut parser = JsonParser::new(&mut feeder);
+//! let mut parser = JsonParser::new();
 //! let mut i: usize = 0;
 //! loop {
 //!     // feed as many bytes as possible to the parser
-//!     let mut event = parser.next_event();
+//!     let mut event = parser.next_event(&mut feeder);
 //!     while event == JsonEvent::NeedMoreInput {
-//!         i += parser.feeder.push_bytes(&json[i..]);
+//!         i += feeder.push_bytes(&json[i..]);
 //!         if i == json.len() {
-//!             parser.feeder.done();
+//!             feeder.done();
 //!         }
-//!         event = parser.next_event();
+//!         event = parser.next_event(&mut feeder);
 //!     }
 //!
 //!     // do something useful with `event`
@@ -75,12 +75,12 @@
 //!     let mut reader = BufReader::new(file);
 //!
 //!     let mut feeder = AsyncBufReaderJsonFeeder::new(&mut reader);
-//!     let mut parser = JsonParser::new(&mut feeder);
+//!     let mut parser = JsonParser::new();
 //!     loop {
-//!         let mut event = parser.next_event();
+//!         let mut event = parser.next_event(&mut feeder);
 //!         if event == JsonEvent::NeedMoreInput {
-//!             parser.feeder.fill_buf().await.unwrap();
-//!             event = parser.next_event();
+//!             feeder.fill_buf().await.unwrap();
+//!             event = parser.next_event(&mut feeder);
 //!         }
 //!
 //!         // do something useful with `event`
@@ -117,12 +117,12 @@
 //! let mut reader = BufReader::new(file);
 //!
 //! let mut feeder = BufReaderJsonFeeder::new(&mut reader);
-//! let mut parser = JsonParser::new(&mut feeder);
+//! let mut parser = JsonParser::new();
 //! loop {
-//!     let mut event = parser.next_event();
+//!     let mut event = parser.next_event(&mut feeder);
 //!     if event == JsonEvent::NeedMoreInput {
-//!         parser.feeder.fill_buf().unwrap();
-//!         event = parser.next_event();
+//!         feeder.fill_buf().unwrap();
+//!         event = parser.next_event(&mut feeder);
 //!     }
 //!
 //!     // do something useful with `event`
@@ -150,9 +150,9 @@
 //! let json = r#"{"name": "Elvis"}"#.as_bytes();
 //!
 //! let mut feeder = SliceJsonFeeder::new(json);
-//! let mut parser = JsonParser::new(&mut feeder);
+//! let mut parser = JsonParser::new();
 //! loop {
-//!     let event = parser.next_event();
+//!     let event = parser.next_event(&mut feeder);
 //!
 //!     // do something useful with `event`
 //!     // match event {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -148,12 +148,7 @@ const MODE_KEY: i8 = 2;
 const MODE_OBJECT: i8 = 3;
 
 /// A non-blocking, event-based JSON parser.
-pub struct JsonParser<'a, T>
-where
-    T: JsonFeeder,
-{
-    pub feeder: &'a mut T,
-
+pub struct JsonParser {
     /// The stack containing the current modes
     stack: Vec<i8>,
 
@@ -174,13 +169,9 @@ where
     event2: JsonEvent,
 }
 
-impl<'a, T> JsonParser<'a, T>
-where
-    T: JsonFeeder,
-{
-    pub fn new(feeder: &'a mut T) -> Self {
+impl JsonParser {
+    pub fn new() -> Self {
         JsonParser {
-            feeder,
             stack: vec![MODE_DONE],
             depth: 2048,
             state: GO,
@@ -190,9 +181,8 @@ where
         }
     }
 
-    pub fn new_with_max_depth(feeder: &'a mut T, max_depth: usize) -> Self {
+    pub fn new_with_max_depth(max_depth: usize) -> Self {
         JsonParser {
-            feeder,
             stack: vec![MODE_DONE],
             depth: max_depth,
             state: GO,
@@ -223,9 +213,9 @@ where
     /// Call this method to proceed parsing the JSON text and to get the next
     /// event. The method returns [`JsonEvent::NeedMoreInput`] if it needs
     /// more input data from the given feeder.
-    pub fn next_event(&mut self) -> JsonEvent {
+    pub fn next_event<F: JsonFeeder>(&mut self, feeder: &mut F) -> JsonEvent {
         while self.event1 == JsonEvent::NeedMoreInput {
-            if let Some(b) = self.feeder.next_input() {
+            if let Some(b) = feeder.next_input() {
                 if self.state == ST && (32..=127).contains(&b) && b != b'\\' && b != b'"' {
                     // shortcut
                     self.current_buffer.push(b);
@@ -233,7 +223,7 @@ where
                     self.parse(b);
                 }
             } else {
-                if self.feeder.is_done() {
+                if feeder.is_done() {
                     if self.state != OK {
                         let r = self.state_to_event();
                         if r != JsonEvent::NeedMoreInput {

--- a/src/serde_json/mod.rs
+++ b/src/serde_json/mod.rs
@@ -6,10 +6,7 @@ use crate::{JsonEvent, JsonParser};
 #[derive(Debug, Clone)]
 pub struct ParserError;
 
-fn to_value<T>(event: &JsonEvent, parser: &JsonParser<T>) -> Option<Value>
-where
-    T: JsonFeeder,
-{
+fn to_value(event: &JsonEvent, parser: &JsonParser) -> Option<Value> {
     match event {
         JsonEvent::ValueString => Some(Value::String(parser.current_string().unwrap())),
 
@@ -48,14 +45,14 @@ where
 /// ```
 pub fn from_slice(v: &[u8]) -> Result<Value, ParserError> {
     let mut feeder = SliceJsonFeeder::new(v);
-    let mut parser = JsonParser::new(&mut feeder);
+    let mut parser = JsonParser::new();
 
     let mut stack = vec![];
     let mut result = None;
     let mut current_key = None;
 
     loop {
-        let event = parser.next_event();
+        let event = parser.next_event(&mut feeder);
         match event {
             JsonEvent::NeedMoreInput => {}
 

--- a/tests/feeder/bufreader.rs
+++ b/tests/feeder/bufreader.rs
@@ -62,14 +62,14 @@ fn parse_from_file() {
     let mut reader = BufReader::with_capacity(32, file);
 
     let mut feeder = BufReaderJsonFeeder::new(&mut reader);
-    let mut parser = JsonParser::new(&mut feeder);
+    let mut parser = JsonParser::new();
     let mut prettyprinter = PrettyPrinter::new();
 
     loop {
-        let mut e = parser.next_event();
+        let mut e = parser.next_event(&mut feeder);
         if e == JsonEvent::NeedMoreInput {
-            parser.feeder.fill_buf().unwrap();
-            e = parser.next_event();
+            feeder.fill_buf().unwrap();
+            e = parser.next_event(&mut feeder);
         }
 
         assert_ne!(e, JsonEvent::Error);

--- a/tests/prettyprinter/mod.rs
+++ b/tests/prettyprinter/mod.rs
@@ -130,14 +130,11 @@ impl PrettyPrinter {
         self.result.push_str("null");
     }
 
-    pub fn on_event<T>(
+    pub fn on_event(
         &mut self,
         event: JsonEvent,
-        parser: &JsonParser<T>,
-    ) -> Result<(), Box<dyn Error>>
-    where
-        T: JsonFeeder,
-    {
+        parser: &JsonParser,
+    ) -> Result<(), Box<dyn Error>> {
         match event {
             JsonEvent::NeedMoreInput => {}
             JsonEvent::StartObject => self.on_start_object(),

--- a/tests/tokio/asyncbufreader.rs
+++ b/tests/tokio/asyncbufreader.rs
@@ -63,14 +63,14 @@ async fn parse_from_file() {
     let mut reader = BufReader::with_capacity(32, file);
 
     let mut feeder = AsyncBufReaderJsonFeeder::new(&mut reader);
-    let mut parser = JsonParser::new(&mut feeder);
+    let mut parser = JsonParser::new();
     let mut prettyprinter = PrettyPrinter::new();
 
     loop {
-        let mut e = parser.next_event();
+        let mut e = parser.next_event(&mut feeder);
         if e == JsonEvent::NeedMoreInput {
-            parser.feeder.fill_buf().await.unwrap();
-            e = parser.next_event();
+            feeder.fill_buf().await.unwrap();
+            e = parser.next_event(&mut feeder);
         }
 
         assert_ne!(e, JsonEvent::Error);


### PR DESCRIPTION
Remove the generic `feeder` field from `JsonParser`

The parser having a reference to the feeder makes it difficult to create structs that wrap both the parser and the feeder (as this would lead to a self-referential struct). It also  leads to the entire parser needing to be gerneric, both over the specific type of the feeder and the lifetime of the reference.

This change removes the generic constraints on the parser. An exclusive reference can be passed as an argument to `JsonParser::next_event(..)` instead. Only this method needs to be gerneric.

Adapted test and doc-tests to comply with the change.

Fixes #4