### PR TITLE
Remove lexical dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,8 +6,9 @@ version = 3
 name = "actson"
 version = "0.3.0"
 dependencies = [
+ "btoi",
  "criterion",
- "lexical",
+ "dtoa",
  "serde_json",
  "tokio",
 ]
@@ -74,6 +75,15 @@ name = "bitflags"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
+
+[[package]]
+name = "btoi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd6407f73a9b8b6162d8a2ef999fe6afd7cc15902ebf42c5cd296addf17e0ad"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "bumpalo"
@@ -228,6 +238,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dtoa"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcbb2bf8e87535c23f7a8a321e364ce21462d0ff10cb6407820e8e96dfff6653"
+
+[[package]]
 name = "either"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -294,79 +310,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cee9c64da59eae3b50095c18d3e74f8b73c0b86d2792824ff01bbce68ba229ca"
 dependencies = [
  "wasm-bindgen",
-]
-
-[[package]]
-name = "lexical"
-version = "6.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7aefb36fd43fef7003334742cbf77b243fcd36418a1d1bdd480d613a67968f6"
-dependencies = [
- "lexical-core",
-]
-
-[[package]]
-name = "lexical-core"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cde5de06e8d4c2faabc400238f9ae1c74d5412d03a7bd067645ccbc47070e46"
-dependencies = [
- "lexical-parse-float",
- "lexical-parse-integer",
- "lexical-util",
- "lexical-write-float",
- "lexical-write-integer",
-]
-
-[[package]]
-name = "lexical-parse-float"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683b3a5ebd0130b8fb52ba0bdc718cc56815b6a097e28ae5a6997d0ad17dc05f"
-dependencies = [
- "lexical-parse-integer",
- "lexical-util",
- "static_assertions",
-]
-
-[[package]]
-name = "lexical-parse-integer"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d0994485ed0c312f6d965766754ea177d07f9c00c9b82a5ee62ed5b47945ee9"
-dependencies = [
- "lexical-util",
- "static_assertions",
-]
-
-[[package]]
-name = "lexical-util"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5255b9ff16ff898710eb9eb63cb39248ea8a5bb036bea8085b1a767ff6c4e3fc"
-dependencies = [
- "static_assertions",
-]
-
-[[package]]
-name = "lexical-write-float"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accabaa1c4581f05a3923d1b4cfd124c329352288b7b9da09e766b0668116862"
-dependencies = [
- "lexical-util",
- "lexical-write-integer",
- "static_assertions",
-]
-
-[[package]]
-name = "lexical-write-integer"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1b6f3d1f4422866b68192d62f77bc5c700bee84f3069f2469d7bc8c77852446"
-dependencies = [
- "lexical-util",
- "static_assertions",
 ]
 
 [[package]]
@@ -607,12 +550,6 @@ dependencies = [
  "ryu",
  "serde",
 ]
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,13 @@ tokio = ["dep:tokio"]
 serde_json = ["dep:serde_json"]
 
 [dependencies]
-lexical = "6.1.1"
+btoi = "0.4.3"
 serde_json = { version = "1.0.111", features = ["float_roundtrip"], optional = true }
 tokio = { version = "1.35.1", features = ["io-util", "rt-multi-thread"], optional = true }
 
 [dev-dependencies]
 criterion = "0.5.1"
+dtoa = "1.0.9"
 serde_json = { version = "1.0.111", features = ["float_roundtrip"] }
 tokio = { version = "1.35.1", features = ["fs", "macros", "rt-multi-thread"]}
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::VecDeque,
     error::Error,
+    num::ParseFloatError,
     str::{from_utf8, Utf8Error},
 };
 
@@ -443,15 +444,17 @@ where
     }
 
     pub fn current_i32(&self) -> Result<i32, Box<dyn Error>> {
-        lexical::parse(&self.current_buffer).map_err(|e| e.into())
+        btoi::btoi(&self.current_buffer).map_err(|e| e.into())
     }
 
     pub fn current_i64(&self) -> Result<i64, Box<dyn Error>> {
-        lexical::parse(&self.current_buffer).map_err(|e| e.into())
+        btoi::btoi(&self.current_buffer).map_err(|e| e.into())
     }
 
     pub fn current_f64(&self) -> Result<f64, Box<dyn Error>> {
-        lexical::parse(&self.current_buffer).map_err(|e| e.into())
+        self.current_string()?
+            .parse()
+            .map_err(|e: ParseFloatError| e.into())
     }
 
     pub fn parsed_bytes(&self) -> usize {

--- a/tests/prettyprinter/mod.rs
+++ b/tests/prettyprinter/mod.rs
@@ -117,7 +117,8 @@ impl PrettyPrinter {
 
     fn on_value_double(&mut self, value: f64) {
         self.on_value();
-        self.result.push_str(&lexical::to_string(value));
+        let mut buf = dtoa::Buffer::new();
+        self.result.push_str(buf.format(value));
     }
 
     fn on_value_boolean(&mut self, value: bool) {


### PR DESCRIPTION
Lexical seems to be unmaintained and has an open security advisory https://rustsec.org/advisories/RUSTSEC-2023-0055.html.

Parsing has been replaced with `btoi` for ints, and internal rust float parsing, as recommended in the advisory.

Verified that tests pass.